### PR TITLE
Minor improvements to the travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,15 @@ jdk:
   - openjdk7
 
 before_script:
-  - cd src/ && mvn install -DskipTests=true -Dmaven.javadoc.skip=true
+  - cd src/
+  - mvn --version
+  - mvn --batch-mode --threads 2.0C -DskipTests=true -Dmaven.javadoc.skip=true install
 
 script:
-  - mvn clean test
+  - mvn --batch-mode --threads 2.0C clean test
 
 after_success:
-  - mvn clean cobertura:cobertura coveralls:cobertura
+  - mvn --batch-mode --threads 2.0C clean cobertura:cobertura coveralls:cobertura
 
 after_script:
   - cd ..


### PR DESCRIPTION
This changes some parts of the travis configuration:
- split the `before_script` section into multiple parts
- print the Maven version before actually testing
- set the `--batch-mode` flag as we are running in non-interactive mode
- set the `--threads` configuration to use 2 threads per available cpu core

The `--threads` configuration should also speed-up the travis job.

This isn't ready for review yet, I want to wait whether travis likes these changes.
