### PR TITLE
Dao test refactoring

### DIFF
--- a/src/shogun2-core/shogun2-dao/src/test/java/de/terrestris/shogun2/dao/ApplicationDaoTest.java
+++ b/src/shogun2-core/shogun2-dao/src/test/java/de/terrestris/shogun2/dao/ApplicationDaoTest.java
@@ -6,8 +6,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.lang.RandomStringUtils;
-import org.joda.time.DateTime;
-import org.joda.time.ReadableDateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -134,110 +132,6 @@ public class ApplicationDaoTest {
 		assertEquals(id, app.getId());
 		assertEquals(changedNameOfApp, app.getName());
 		assertEquals(changedDescOfApp, app.getDescription());
-	}
-
-	/**
-	 * Tests whether the automatic setting of field modified happens when
-	 * creating.
-	 */
-	@Test
-	public void saveOrUpdate_shouldSetModified() {
-		// first create an application and save it.
-		Application app = getRandomUnsavedMockApp();
-
-		// Model tests should ensure that the constructor populates modified
-		ReadableDateTime before = app.getModified();
-
-		try {
-			// ... wait ...
-			Thread.sleep(50);
-
-			// ... then save
-			applicationDao.saveOrUpdate(app);
-
-			ReadableDateTime after = app.getModified();
-
-			// They should be different
-			assertNotEquals(before, after);
-			assertFalse(before.equals(after));
-			// after should be greater than before
-			boolean isLater = before.compareTo(after) == -1;
-			assertTrue(isLater);
-		} catch (InterruptedException e) {
-			fail("Caught exception while attempting to wait");
-			return;
-		}
-
-	}
-
-	/**
-	 * Tests whether saveOrUpdate cannot be tricked by explicitly setting field
-	 * modified.
-	 */
-	@Test
-	public void saveOrUpdate_shouldAlwaysSetModified() {
-		// first create an application and save it.
-		Application app = getRandomUnsavedMockApp();
-
-		try {
-			// ... wait ...
-			Thread.sleep(50);
-
-			// ... then update the modified field
-			DateTime before = DateTime.now();
-			app.setModified(before);
-
-			// ... wait ...
-			Thread.sleep(50);
-
-			// ... and only then save, modified should differ now
-			applicationDao.saveOrUpdate(app);
-			ReadableDateTime after = app.getModified();
-
-			// They should be different
-			assertNotEquals(before, after);
-			assertFalse(before.equals(after));
-			// after should be greater than before
-			boolean isLater = before.compareTo(after) == -1;
-			assertTrue(isLater);
-
-		} catch (InterruptedException e) {
-			fail("Caught exception while attempting to wait");
-			return;
-		}
-
-	}
-
-	/**
-	 * Tests whether an UPDATE results in updating the field modified.
-	 */
-	@Test
-	public void saveOrUpdate_shouldUpdateModified() {
-		// first create an application and save it.
-		Application app = getRandomUnsavedMockApp();
-		applicationDao.saveOrUpdate(app);
-
-		ReadableDateTime before = app.getModified();
-
-		try {
-			Thread.sleep(50);
-			// change the application
-			app.setName("Some other name");
-			app.setDescription("Changed description");
-			applicationDao.saveOrUpdate(app);
-			ReadableDateTime after = app.getModified();
-
-			// They should be different
-			assertNotEquals(before, after);
-			assertFalse(before.equals(after));
-			// after should be greater than before
-			boolean isLater = before.compareTo(after) == -1;
-			assertTrue(isLater);
-		} catch (InterruptedException e) {
-			fail("Caught exception while attempting to wait");
-			return;
-		}
-
 	}
 
 	/**

--- a/src/shogun2-core/shogun2-dao/src/test/java/de/terrestris/shogun2/dao/GenericHibernateDaoTest.java
+++ b/src/shogun2-core/shogun2-dao/src/test/java/de/terrestris/shogun2/dao/GenericHibernateDaoTest.java
@@ -1,0 +1,146 @@
+package de.terrestris.shogun2.dao;
+
+import static org.junit.Assert.*;
+
+import org.joda.time.DateTime;
+import org.joda.time.ReadableDateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.transaction.TransactionConfiguration;
+import org.springframework.transaction.annotation.Transactional;
+
+import de.terrestris.shogun2.model.Application;
+
+/**
+ * 
+ * @author Marc Jansen
+ * @author Nils Bühner
+ * 
+ *         This class will test the {@link GenericHibernateDao}. As
+ *         {@link GenericHibernateDao} is an abstract class, we cannot
+ *         instantiate it. Instead we will use the {@link ApplicationDao} (as an
+ *         simple extension of {@link GenericHibernateDao}) to test the logic
+ *         contained in {@link GenericHibernateDao}.
+ * 
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath*:META-INF/spring/test-context-dao.xml" })
+@Transactional
+@TransactionConfiguration(defaultRollback = true)
+public class GenericHibernateDaoTest {
+
+	/**
+	 * We use the {@link ApplicationDao} to test the behaviour of the
+	 * {@link GenericHibernateDao} (which is an abstract class and cannot be
+	 * instantiated).
+	 */
+	@Autowired
+	ApplicationDao applicationDao;
+
+	/**
+	 * Tests whether the automatic setting of field modified happens when
+	 * creating.
+	 */
+	@Test
+	public void saveOrUpdate_shouldSetModified() {
+		// first create an application and save it.
+		Application app = new Application("Some Name", "Some description");
+
+		// Model tests should ensure that the constructor populates modified
+		ReadableDateTime before = app.getModified();
+
+		try {
+			// ... wait ...
+			Thread.sleep(1);
+
+			// ... then save
+			applicationDao.saveOrUpdate(app);
+
+			ReadableDateTime after = app.getModified();
+
+			// They should be different
+			assertNotEquals(before, after);
+
+			// after should be greater than before
+			boolean isLater = before.compareTo(after) == -1;
+			assertTrue(isLater);
+		} catch (InterruptedException e) {
+			fail("Caught exception while attempting to wait");
+			return;
+		}
+
+	}
+
+	/**
+	 * Tests whether saveOrUpdate cannot be tricked by explicitly setting field
+	 * modified.
+	 */
+	@Test
+	public void saveOrUpdate_shouldAlwaysSetModified() {
+		// first create an application and save it.
+		Application app = new Application("Some Name", "Some description");
+
+		try {
+			// ... wait ...
+			Thread.sleep(1);
+
+			// ... then update the modified field
+			DateTime before = DateTime.now();
+			app.setModified(before);
+
+			// ... wait ...
+			Thread.sleep(1);
+
+			// ... and only then save, modified should differ now
+			applicationDao.saveOrUpdate(app);
+			ReadableDateTime after = app.getModified();
+
+			// They should be different
+			assertNotEquals(before, after);
+
+			// after should be greater than before
+			boolean isLater = before.compareTo(after) == -1;
+			assertTrue(isLater);
+
+		} catch (InterruptedException e) {
+			fail("Caught exception while attempting to wait");
+			return;
+		}
+
+	}
+
+	/**
+	 * Tests whether an UPDATE results in updating the field modified.
+	 */
+	@Test
+	public void saveOrUpdate_shouldUpdateModified() {
+		// first create an application and save it.
+		Application app = new Application("Some Name", "Some description");
+		applicationDao.saveOrUpdate(app);
+
+		ReadableDateTime before = app.getModified();
+
+		try {
+			Thread.sleep(1);
+			// change the application
+			app.setName("Some other name");
+			app.setDescription("Changed description");
+			applicationDao.saveOrUpdate(app);
+			ReadableDateTime after = app.getModified();
+
+			// They should be different
+			assertNotEquals(before, after);
+
+			// after should be greater than before
+			boolean isLater = before.compareTo(after) == -1;
+			assertTrue(isLater);
+		} catch (InterruptedException e) {
+			fail("Caught exception while attempting to wait");
+			return;
+		}
+	}
+
+}


### PR DESCRIPTION
The ApplicationDaoTest had some methods to test if the modified field is working correctly. As this field is being updated in the GenericHibernateDao, this behaviour should be tested in a test for the GenericHibernateDao (and not in the ApplicationDaoTest). For this reason a new test "GenericHibnernateDaoTest" has been created (to have some kind of semantic separation). As GenericHibernateDao is an abstract class, we cannot instantiate it to test this. Hence the ApplicationDao (as an simple extension of the GenericHibernateDao) is used in the new test.
