### PR TITLE
Set all serialVersionUIDs to 1L.

### DIFF
--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Application.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
 @Table
 public class Application extends PersistentObject {
 
-	private static final long serialVersionUID = -8121493601745944561L;
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * The name of the application.

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/PersistentObject.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/PersistentObject.java
@@ -36,7 +36,7 @@ import org.joda.time.ReadableDateTime;
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 public abstract class PersistentObject implements Serializable {
 
-	private static final long serialVersionUID = 8299954175165022499L;
+	private static final long serialVersionUID = 1L;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.TABLE)

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Person.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/Person.java
@@ -21,7 +21,7 @@ import org.joda.time.LocalDate;
 @Table
 public class Person extends PersistentObject {
 
-	private static final long serialVersionUID = 7056396802609951521L;
+	private static final long serialVersionUID = 1L;
 
 	@Column
 	private String firstName;

--- a/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
+++ b/src/shogun2-core/shogun2-model/src/main/java/de/terrestris/shogun2/model/User.java
@@ -17,7 +17,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
 @Table
 public class User extends Person {
 
-	private static final long serialVersionUID = -4655851586457507906L;
+	private static final long serialVersionUID = 1L;
 
 	@Column
 	private String accountName;

--- a/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/model/ProjectApplication.java
+++ b/src/shogun2-webapp-archetype/src/main/resources/archetype-resources/src/main/java/model/ProjectApplication.java
@@ -17,7 +17,7 @@ import de.terrestris.shogun2.model.Application;
 @Table
 public class ProjectApplication extends Application {
 
-	private static final long serialVersionUID = -4035430327848743034L;
+	private static final long serialVersionUID = 1L;
 
 	@Column
 	private String projectSpecificString;


### PR DESCRIPTION
The generated serialVersionUIDs are ugly to maintain. After a future release, we can easily increment the serialVersionUID of a model if it's attributes or methods changes.

Feel free to merge!
