### PR TITLE
Use in-memory-db for the DAO test.

### DIFF
--- a/src/shogun2-core/shogun2-dao/src/test/resources/META-INF/jdbc.properties
+++ b/src/shogun2-core/shogun2-dao/src/test/resources/META-INF/jdbc.properties
@@ -1,8 +1,3 @@
-#jdbc.driverClassName=org.postgresql.Driver
-#jdbc.url=jdbc:postgresql://localhost:5432/mydatabase
-#jdbc.username=myuser
-#jdbc.password=mypassword
-
 jdbc.driverClassName=org.h2.Driver
 jdbc.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
 jdbc.username=admin


### PR DESCRIPTION
By using /tmp, the file will (usually) be cleaned up after a reboot.
