### PR TITLE
Exclude model package from Cobertura coverage test

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -134,7 +134,7 @@
                         <!-- exclude all model-classes because
                              they will not be covered by a test -->
                         <excludes>
-                            <exclude>de/terrestris/shogun2/model/*.class]</exclude>
+                            <exclude>de/terrestris/shogun2/model/*.class</exclude>
                         </excludes>
                     </instrumentation>
                 </configuration>


### PR DESCRIPTION
The model classes will not be tested explicitly. Therefore they should by excluded from the coverage test.
