### PR TITLE
Add support for custom endpoints

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.terrestris</groupId>
     <artifactId>shogun2</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>SHOGun2</name>
     <description>SHOGun2 is a Java based WebGIS framework</description>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -50,6 +50,11 @@
 
     <repositories>
         <repository>
+            <id>terrestris</id>
+            <name>SHOGun Snapshot Repository</name>
+            <url>https://nexus.terrestris.de/repository/public/</url>
+        </repository>
+        <repository>
             <id>sonatype-snapshots</id>
             <name>Sonatype Snapshots</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
@@ -239,6 +244,8 @@
         <site-plugin.version>3.6</site-plugin.version>
         <resources-plugin.version>3.0.2</resources-plugin.version>
         <project-info-reports-plugin.version>2.9</project-info-reports-plugin.version>
+        <deegree.version>3.4.4</deegree.version>
+        <interceptor.version>1.2</interceptor.version>
 
         <downloadSources>true</downloadSources>
         <downloadJavadocs>true</downloadJavadocs>
@@ -998,6 +1005,18 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.deegree</groupId>
+                <artifactId>deegree-core-commons</artifactId>
+                <version>${deegree.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.interceptor</groupId>
+                <artifactId>javax.interceptor-api</artifactId>
+                <version>${interceptor.version}</version>
             </dependency>
 
         </dependencies>

--- a/src/shogun2-core/pom.xml
+++ b/src/shogun2-core/pom.xml
@@ -277,6 +277,16 @@
             <artifactId>zip4j</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.deegree</groupId>
+            <artifactId>deegree-core-commons</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.interceptor</groupId>
+            <artifactId>javax.interceptor-api</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/src/shogun2-core/pom.xml
+++ b/src/shogun2-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.terrestris</groupId>
         <artifactId>shogun2</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>shogun2-core</artifactId>

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/ImageWmsLayerDataSource.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/ImageWmsLayerDataSource.java
@@ -1,14 +1,14 @@
 package de.terrestris.shogun2.model.layer.source;
 
-import javax.persistence.Cacheable;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
 
 /**
  * Class representing a layer data source for WMS servers providing single,
@@ -42,6 +42,12 @@ public class ImageWmsLayerDataSource extends LayerDataSource {
     @Column(length = 2048)
     private String layerStyles;
 
+    @Column
+    private Boolean requestableByPath;
+
+    @Column
+    private String customRequestPath;
+
     /**
      *
      */
@@ -56,8 +62,8 @@ public class ImageWmsLayerDataSource extends LayerDataSource {
      * @param width   image width
      * @param height  image height
      * @param version WMS version
-     * @param layers  List of layer names (instance if {@link GeoWebServiceLayerName}
-     * @param styles  List of layer styles (instance if {@link GeoWebServiceLayerStyle}
+     * @param layerNames List of layer names
+     * @param layerStyles  List of layer styles
      */
     public ImageWmsLayerDataSource(String name, String type, String url, int width,
                                    int height, String version, String layerNames, String layerStyles) {
@@ -185,4 +191,19 @@ public class ImageWmsLayerDataSource extends LayerDataSource {
             isEquals();
     }
 
+    public Boolean getRequestableByPath() {
+        return requestableByPath;
+    }
+
+    public void setRequestableByPath( Boolean requestableByPath ) {
+        this.requestableByPath = requestableByPath;
+    }
+
+    public String getCustomRequestPath() {
+        return customRequestPath;
+    }
+
+    public void setCustomRequestPath( String customRequestPath ) {
+        this.customRequestPath = customRequestPath;
+    }
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/model/layer/source/TileWmsLayerDataSource.java
@@ -1,21 +1,15 @@
 package de.terrestris.shogun2.model.layer.source;
 
-import javax.persistence.Cacheable;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-
+import de.terrestris.shogun2.model.layer.util.TileGrid;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.CascadeType;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.*;
 
-import de.terrestris.shogun2.model.layer.util.TileGrid;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.*;
 
 /**
  * Data source of layers for tile data from WMS servers.
@@ -60,8 +54,8 @@ public class TileWmsLayerDataSource extends ImageWmsLayerDataSource {
      * @param width
      * @param height
      * @param version
-     * @param layers
-     * @param styles
+     * @param layerNames
+     * @param layerStyles
      * @param tileGrid
      */
     public TileWmsLayerDataSource(String name, String type, String url, int width,

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/service/GeoServerInterceptorService.java
@@ -102,13 +102,31 @@ public class GeoServerInterceptorService {
      * @throws HttpException
      * @throws IOException
      */
-    public Response interceptGeoServerRequest(HttpServletRequest request)
+    public Response interceptGeoServerRequest( HttpServletRequest request )
+        throws InterceptorException, URISyntaxException,
+        HttpException, IOException {
+        return interceptGeoServerRequest( request, Optional.empty() );
+    }
+
+    /**
+     * @param request
+     * @param endpoint
+     * @return
+     * @throws InterceptorException
+     * @throws URISyntaxException
+     * @throws HttpException
+     * @throws IOException
+     */
+    public Response interceptGeoServerRequest( HttpServletRequest request, Optional<String> endpoint )
         throws InterceptorException, URISyntaxException,
         HttpException, IOException {
 
         // wrap the request, we want to manipulate it
         MutableHttpServletRequest mutableRequest =
             new MutableHttpServletRequest(request);
+        if (endpoint.isPresent()) {
+            mutableRequest.addParameter("CUSTOM_ENDPOINT", endpoint.get());
+        }
 
         // get the OGC message information (service, request, endPoint)
         OgcMessage message = getOgcMessage(mutableRequest);

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
@@ -310,4 +310,19 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
         }
     }
 
+    /**
+     * Get a parameter by name, ignoring case.
+     *
+     * @param name the parameter to get
+     * @return a comma separated list of parameter values
+     */
+    public String getParameterIgnoreCase(String name) {
+        for (Map.Entry<String, String[]> entry : customParameters.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(name)) {
+                return StringUtils.join(entry.getValue(), ",");
+            }
+        }
+        return null;
+    }
+
 }

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/standard/WmsRequestInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/standard/WmsRequestInterceptor.java
@@ -1,0 +1,83 @@
+package de.terrestris.shogun2.util.interceptor.standard;
+
+import de.terrestris.shogun2.dao.LayerDataSourceDao;
+import de.terrestris.shogun2.model.layer.source.ImageWmsLayerDataSource;
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+import de.terrestris.shogun2.util.interceptor.WmsRequestInterceptorInterface;
+import org.hibernate.criterion.LogicalExpression;
+import org.hibernate.criterion.Restrictions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import javax.transaction.Transactional;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This class demonstrates how to implement the WmsRequestInterceptorInterface.
+ *
+ * @author Daniel Koch
+ * @author Andre Henn
+ * @author terrestris GmbH & Co. KG
+ */
+public class WmsRequestInterceptor implements WmsRequestInterceptorInterface {
+
+    @Autowired
+    @Qualifier("layerDataSourceDao")
+    private LayerDataSourceDao<ImageWmsLayerDataSource> layerDataSourceDao;
+
+    private void filterLayerParameter(String name, MutableHttpServletRequest request) {
+        String endpoint = request.getParameterIgnoreCase("CUSTOM_ENDPOINT");
+        if (endpoint == null) {
+            return;
+        }
+        String layers = request.getParameterIgnoreCase(name);
+        String[] fromRequest = layers.split(",");
+
+        LogicalExpression where = Restrictions.and(
+            Restrictions.eq("requestableByPath", true),
+            Restrictions.eq("customRequestPath", endpoint)
+        );
+        List<ImageWmsLayerDataSource> sources = this.layerDataSourceDao.findByCriteria(where);
+        List<String> layersInPath = sources.parallelStream().map(ImageWmsLayerDataSource::getLayerNames).collect(Collectors.toList());
+        List<String> resultLayers = Arrays.stream(fromRequest).filter(layersInPath::contains).collect(Collectors.toList());
+        request.setParameter(name, resultLayers.stream().reduce("", (acc, val) -> acc.isEmpty() ? val : acc + "," + val));
+    }
+
+    @Override
+    @Transactional(value = Transactional.TxType.REQUIRED)
+    public MutableHttpServletRequest interceptGetMap(MutableHttpServletRequest request) {
+        filterLayerParameter("LAYERS", request);
+        return request;
+    }
+
+    @Override
+    public MutableHttpServletRequest interceptGetCapabilities(MutableHttpServletRequest request) {
+        return request;
+    }
+
+    @Override
+    public MutableHttpServletRequest interceptGetFeatureInfo(MutableHttpServletRequest request) {
+        filterLayerParameter("LAYERS", request);
+        filterLayerParameter("QUERY_LAYERS", request);
+        return request;
+    }
+
+    @Override
+    public MutableHttpServletRequest interceptDescribeLayer(MutableHttpServletRequest request) {
+        return request;
+    }
+
+    @Override
+    public MutableHttpServletRequest interceptGetLegendGraphic(MutableHttpServletRequest request) {
+        filterLayerParameter("LAYER", request);
+        return request;
+    }
+
+    @Override
+    public MutableHttpServletRequest interceptGetStyles(MutableHttpServletRequest request) {
+        return request;
+    }
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/standard/WmsResponseInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/standard/WmsResponseInterceptor.java
@@ -1,0 +1,154 @@
+package de.terrestris.shogun2.util.interceptor.standard;
+
+import de.terrestris.shogun2.dao.LayerDataSourceDao;
+import de.terrestris.shogun2.model.layer.source.ImageWmsLayerDataSource;
+import de.terrestris.shogun2.util.interceptor.MutableHttpServletRequest;
+import de.terrestris.shogun2.util.interceptor.WmsResponseInterceptorInterface;
+import de.terrestris.shogun2.util.model.Response;
+import org.apache.logging.log4j.Logger;
+import org.deegree.commons.xml.CommonNamespaces;
+import org.hibernate.criterion.LogicalExpression;
+import org.hibernate.criterion.Restrictions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.transaction.Transactional;
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.logging.log4j.LogManager.getLogger;
+
+/**
+ * This class demonstrates how to implement the WmsResponseInterceptorInterface.
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class WmsResponseInterceptor implements WmsResponseInterceptorInterface {
+
+    private static final Logger LOG = getLogger(WmsResponseInterceptor.class);
+
+    @Autowired
+    @Qualifier("layerDataSourceDao")
+    private LayerDataSourceDao<ImageWmsLayerDataSource> layerDataSourceDao;
+
+    @Override
+    public Response interceptGetMap(MutableHttpServletRequest request, Response response) {
+        // the existing http header
+        HttpHeaders existingHeaders = response.getHeaders();
+        // the new http header
+        HttpHeaders modifiedHeaders = new HttpHeaders();
+
+        // make a copy of all existing http headers
+        modifiedHeaders.putAll(existingHeaders);
+
+        // add no-cache headers
+        modifiedHeaders.setCacheControl("no-cache, no-store, must-revalidate");
+        modifiedHeaders.setPragma("no-cache");
+        modifiedHeaders.setExpires(0);
+
+        response.setHeaders(modifiedHeaders);
+
+        return response;
+    }
+
+    private void removeLayers(Document doc, String namespace, List<String> layerNames) throws XPathExpressionException {
+        layerNames = layerNames.parallelStream().map(layerName -> layerName.split(":")[1]).collect(Collectors.toList());
+        XPathFactory factory = XPathFactory.newInstance();
+        XPath xpath = factory.newXPath();
+        NamespaceContext nscontext = CommonNamespaces.getNamespaceContext();
+        xpath.setNamespaceContext(nscontext);
+        String prefix = namespace.equals("") ? "" : "wms:";
+        XPathExpression expr = xpath.compile("//" + prefix + "Layer/" + prefix + "Name");
+        NodeList nodeList = (NodeList) expr.evaluate(doc, XPathConstants.NODESET);
+        List<Element> toRemove = new ArrayList<>();
+        for (int i = 0; i < nodeList.getLength(); ++i) {
+            Element name = (Element) nodeList.item(i);
+            String str = name.getTextContent();
+            if (!layerNames.contains(str)) {
+                toRemove.add((Element) name.getParentNode());
+            }
+        }
+        toRemove.forEach(element -> element.getParentNode().removeChild(element));
+    }
+
+    @Override
+    @Transactional(value = Transactional.TxType.REQUIRED)
+    public Response interceptGetCapabilities(MutableHttpServletRequest request, Response response) {
+        String endpoint = request.getParameterIgnoreCase("CUSTOM_ENDPOINT");
+        if (endpoint == null) {
+            return response;
+        }
+        LogicalExpression where = Restrictions.and(
+            Restrictions.eq("requestableByPath", true),
+            Restrictions.eq("customRequestPath", endpoint)
+        );
+        List<ImageWmsLayerDataSource> sources = this.layerDataSourceDao.findByCriteria(where);
+        List<String> layerNames = sources.parallelStream().map(ImageWmsLayerDataSource::getLayerNames).collect(Collectors.toList());
+
+        byte[] body = response.getBody();
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(new ByteArrayInputStream(body));
+            Element root = doc.getDocumentElement();
+            String version = root.getAttribute("version");
+            System.out.println(version);
+            if (version == null) {
+                return response;
+            }
+            if (version.equals("1.3.0")) {
+                removeLayers(doc, "http://www.opengis.net/wms", layerNames);
+            } else {
+                removeLayers(doc, "", layerNames);
+            }
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            DOMSource source = new DOMSource(doc);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            StreamResult result = new StreamResult(bos);
+            transformer.transform(source, result);
+            response.setBody(bos.toByteArray());
+        } catch (Throwable e) {
+            LOG.warn("Something went wrong when intercepting a get capabilities response: " + e.getMessage());
+            LOG.trace("Stack trace", e);
+        }
+        return response;
+    }
+
+    @Override
+    public Response interceptGetFeatureInfo(MutableHttpServletRequest request, Response response) {
+        return response;
+    }
+
+    @Override
+    public Response interceptDescribeLayer(MutableHttpServletRequest request, Response response) {
+        return response;
+    }
+
+    @Override
+    public Response interceptGetLegendGraphic(MutableHttpServletRequest request, Response response) {
+        return response;
+    }
+
+    @Override
+    public Response interceptGetStyles(MutableHttpServletRequest request, Response response) {
+        return response;
+    }
+
+}

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/GeoServerInterceptorController.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/web/GeoServerInterceptorController.java
@@ -10,12 +10,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.logging.log4j.LogManager.getLogger;
 
@@ -49,10 +51,9 @@ public class GeoServerInterceptorController<S extends GeoServerInterceptorServic
      * @return
      * @throws IOException
      */
-    @RequestMapping(value = "/geoserver.action", method = {
+    @RequestMapping(value = {"/geoserver.action", "/geoserver.action/{endpoint}"}, method = {
         RequestMethod.GET, RequestMethod.POST})
-    public ResponseEntity<?> interceptGeoServerRequest(HttpServletRequest request) {
-
+    public ResponseEntity<?> interceptGeoServerRequest( HttpServletRequest request, @PathVariable(value="endpoint", required = false) Optional<String> endpoint ) {
         HttpHeaders responseHeaders = new HttpHeaders();
         HttpStatus responseStatus = HttpStatus.OK;
         byte[] responseBody = null;
@@ -62,7 +63,7 @@ public class GeoServerInterceptorController<S extends GeoServerInterceptorServic
 
             LOG.trace("Trying to intercept a GeoServer resource.");
 
-            httpResponse = this.service.interceptGeoServerRequest(request);
+            httpResponse = this.service.interceptGeoServerRequest(request, endpoint);
 
             responseStatus = httpResponse.getStatusCode();
             responseBody = httpResponse.getBody();

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/GeoServerInterceptorServiceTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/service/GeoServerInterceptorServiceTest.java
@@ -325,7 +325,7 @@ public class GeoServerInterceptorServiceTest {
             "WMS", "GetStyles", "bvb:yarmolenko", "REQUEST");
 
         assertTrue(EqualsBuilder.reflectionEquals(expectedRule,
-            actualRule, new String[]{"id", "created", "modified"}));
+            actualRule, "id", "created", "modified"));
     }
 
     @Test
@@ -344,7 +344,7 @@ public class GeoServerInterceptorServiceTest {
             "WFS", "DescribeFeatureType", null, "REQUEST");
 
         assertTrue(EqualsBuilder.reflectionEquals(expectedRule,
-            actualRule, new String[]{"id", "created", "modified"}));
+            actualRule, "id", "created", "modified"));
     }
 
     @Test
@@ -362,7 +362,7 @@ public class GeoServerInterceptorServiceTest {
             "WFS", "DescribeFeatureType", null, "REQUEST");
 
         assertTrue(EqualsBuilder.reflectionEquals(expectedRule,
-            actualRule, new String[]{"id", "created", "modified"}));
+            actualRule, "id", "created", "modified"));
     }
 
     @Test
@@ -381,7 +381,7 @@ public class GeoServerInterceptorServiceTest {
             "WMS", null, "bvb:yarmolenko", "REQUEST");
 
         assertTrue(EqualsBuilder.reflectionEquals(expectedRule,
-            actualRule, new String[]{"id", "created", "modified"}));
+            actualRule, "id", "created", "modified"));
     }
 
     @Test(expected = InterceptorException.class)
@@ -526,7 +526,7 @@ public class GeoServerInterceptorServiceTest {
             getTestInterceptorRulesForServiceAndEvent(service, event));
 
         // use powermock whitebox reflection to test private class
-        InterceptorRule mostSpecificRule = Whitebox.<InterceptorRule>invokeMethod(
+        InterceptorRule mostSpecificRule = Whitebox.invokeMethod(
             gsInterceptorService,
             "getMostSpecificRule", service, operation, endPoint, event);
 

--- a/src/shogun2-core/src/test/resources/log4j2.xml
+++ b/src/shogun2-core/src/test/resources/log4j2.xml
@@ -13,6 +13,9 @@
         <Logger additivity="false" name="org.hibernate" level="info">
             <AppenderRef ref="Console" />
         </Logger>
+        <Logger additivity="false" name="org.springframework" level="info">
+            <AppenderRef ref="Console" />
+        </Logger>
         <Logger additivity="false" name="org.hibernate.cache" level="info">
             <AppenderRef ref="Console" />
         </Logger>

--- a/src/shogun2-webapp-archetype/pom.xml
+++ b/src/shogun2-webapp-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.terrestris</groupId>
         <artifactId>shogun2</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>shogun2-webapp-archetype</artifactId>


### PR DESCRIPTION
This supports interceptor urls like `/geoserver.action/somename`. If the layer sources are configured accordingly and the new standard WMS interceptors are configured, the interceptor will only support the layers that are configured with this path at the custom endpoint and filter out the rest. `GetCapabilities`, `GetMap`, `GetFeatureInfo` and `GetLegendGraphic` are supported.

@terrestris/devs Please review.
