### PR TITLE
Allow custom headers for http requests

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
@@ -44,6 +44,11 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
     private Map<String, String[]> customParameters;
 
     /**
+     * Holds custom header mapping
+     */
+    private Map<String, String> customHeaders;
+
+    /**
      *
      */
     private String customRequestURI;
@@ -61,6 +66,7 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
         this.customRequestURI = request.getRequestURI();
         this.customParameters = new HashMap<String, String[]>(
             request.getParameterMap());
+        this.customHeaders = new HashMap<String, String>();
     }
 
     /**
@@ -209,6 +215,17 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
      * @param key
      * @param value
      */
+    public void setHeader(String key, String value) {
+        if (!StringUtils.isEmpty(this.getHeader(key))) {
+            this.removeHeader(key);
+        }
+        customHeaders.put(key, value);
+    }
+
+    /**
+     * @param key
+     * @param value
+     */
     public void addParameter(String key, String[] value) {
         customParameters.put(key, value);
     }
@@ -232,6 +249,15 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
     }
 
     /**
+     * @param key
+     */
+    public void removeHeader(String key) {
+        if (customHeaders.get(key) != null) {
+            customHeaders.remove(key);
+        }
+    }
+
+    /**
      *
      */
     @Override
@@ -250,6 +276,20 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
     @Override
     public Map<String, String[]> getParameterMap() {
         return customParameters;
+    }
+
+    /**
+     *
+     */
+    @Override
+    public String getHeader(String name) {
+        String headerValue = customHeaders.get(name);
+
+        // check the custom headers first
+        if (headerValue != null){
+            return headerValue;
+        }
+        return ((HttpServletRequest) getRequest()).getHeader(name);
     }
 
     /**

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequest.java
@@ -212,8 +212,8 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
     }
 
     /**
-     * @param key
-     * @param value
+     * @param key The header name (without a trailing colon `:`)
+     * @param value The header value
      */
     public void setHeader(String key, String value) {
         if (!StringUtils.isEmpty(this.getHeader(key))) {
@@ -284,8 +284,7 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
     @Override
     public String getHeader(String name) {
         String headerValue = customHeaders.get(name);
-
-        // check the custom headers first
+        // Check custom headers first
         if (headerValue != null){
             return headerValue;
         }

--- a/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequestTest.java
+++ b/src/shogun2-core/src/test/java/de/terrestris/shogun2/util/interceptor/MutableHttpServletRequestTest.java
@@ -32,6 +32,10 @@ public class MutableHttpServletRequestTest {
 
     private static final String CUSTOM_REQUEST_PARAMETER_VALUE = "Kagawa";
 
+    private static final String CUSTOM_REQUEST_HEADER_KEY = "Authorization";
+
+    private static final String CUSTOM_REQUEST_HEADER_VALUE = "U2hpbmppOkthZ2F3YQ==";
+
     private MutableHttpServletRequest mutableRequest;
 
     @Before
@@ -87,6 +91,12 @@ public class MutableHttpServletRequestTest {
         mutableRequest.addParameter(CUSTOM_REQUEST_PARAMETER_KEY, param);
         assertEquals(StringUtils.join(param, ","),
             mutableRequest.getParameter(CUSTOM_REQUEST_PARAMETER_KEY));
+    }
+
+    @Test
+    public void set_custom_header() {
+        mutableRequest.setHeader(CUSTOM_REQUEST_HEADER_KEY, CUSTOM_REQUEST_HEADER_VALUE);
+        assertEquals(CUSTOM_REQUEST_HEADER_VALUE, mutableRequest.getHeader(CUSTOM_REQUEST_HEADER_KEY));
     }
 
     @Test


### PR DESCRIPTION
Adds the option to set custom headers on a `MutableHttpServletRequest` 

@terrestris/devs Pls review