### PR TITLE
Namespace aware handling in default WMS request/response interceptor (1.0.x-master)

### DIFF
--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/standard/WmsRequestInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/standard/WmsRequestInterceptor.java
@@ -58,6 +58,7 @@ public class WmsRequestInterceptor implements WmsRequestInterceptorInterface {
     }
 
     @Override
+    @Transactional(value = Transactional.TxType.REQUIRED)
     public MutableHttpServletRequest interceptGetFeatureInfo(MutableHttpServletRequest request) {
         filterLayerParameter("LAYERS", request);
         filterLayerParameter("QUERY_LAYERS", request);
@@ -70,6 +71,7 @@ public class WmsRequestInterceptor implements WmsRequestInterceptorInterface {
     }
 
     @Override
+    @Transactional(value = Transactional.TxType.REQUIRED)
     public MutableHttpServletRequest interceptGetLegendGraphic(MutableHttpServletRequest request) {
         filterLayerParameter("LAYER", request);
         return request;

--- a/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/standard/WmsResponseInterceptor.java
+++ b/src/shogun2-core/src/main/java/de/terrestris/shogun2/util/interceptor/standard/WmsResponseInterceptor.java
@@ -97,14 +97,14 @@ public class WmsResponseInterceptor implements WmsResponseInterceptorInterface {
         NodeList nodeList = (NodeList) expr.evaluate(doc, XPathConstants.NODESET);
         for (int i = 0; i < nodeList.getLength(); ++i) {
             Element link = (Element) nodeList.item(i);
-            String url = link.getAttributeNS("http://www.w3.org/1999/xlink", "href");
+            String url = link.getAttributeNS("http://www.w3.org/1999/xlink", "xlink:href");
             int index = url.indexOf("?");
             if (index > -1) {
                 url = url.substring(index);
                 url = baseUrl + url;
-                link.setAttributeNS("http://www.w3.org/1999/xlink", "href", url);
+                link.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", url);
             } else {
-                link.setAttributeNS("http://www.w3.org/1999/xlink", "href", baseUrl);
+                link.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", baseUrl);
             }
         }
     }


### PR DESCRIPTION
This fixes the interception of WMS requests and responses in context of the `CUSTOM_ENDPOINT` handling to become more namespace aware:
  * Append `xlink` namespace to element attribute (otherwise clients like QGIS couldn't parse the `GetCapabilities` response).
  * Append the layer's namespace to layername if needed (otherwise we couldn't detect the corresponding GeoServer base URL in subsequent WMS requests as clients like QGIS will make use of the name to generate these requests).
  * Add `@Transactional` annotation to enforce a new JTA transaction if called outside of a transaction context.

Please review @terrestris/devs.
