### PR TITLE
Exclude problematic logging facades

### DIFF
--- a/src/shogun-core-main/pom.xml
+++ b/src/shogun-core-main/pom.xml
@@ -295,6 +295,16 @@
         <dependency>
             <groupId>org.deegree</groupId>
             <artifactId>deegree-core-commons</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
As we are not using log4j in v1, we should exclude these facades as they lead to actual problems