### PR TITLE
Remove hibernate-ehcache dependency

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -833,18 +833,6 @@
                 </exclusions>
             </dependency>
 
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-ehcache</artifactId>
-                <version>${hibernate.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.jboss.logging</groupId>
-                        <artifactId>jboss-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <!-- H2 Database -->
             <dependency>
                 <groupId>com.h2database</groupId>

--- a/src/shogun-core-main/src/test/resources/META-INF/hibernate.properties
+++ b/src/shogun-core-main/src/test/resources/META-INF/hibernate.properties
@@ -8,7 +8,7 @@ hibernate.hbm2ddl.auto=create
 hibernate.cache.use_query_cache=false
 #hibernate.cache.use_second_level_cache=true
 #hibernate.cache.use_query_cache=true
-#hibernate.cache.region.factory_class=net.sf.ehcache.hibernate.EhCacheRegionFactory
+#hibernate.cache.region.factory_class=org.hibernate.cache.jcache.JCacheRegionFactory
 
 # other
 #hibernate.max_fetch_depth=4


### PR DESCRIPTION
Removes the `hibernate-ehcache` dependency as it conflicts with `org.ehcache` in version 3.