### PR TITLE
Use other port for http server when testing

### DIFF
--- a/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/util/http/HttpUtilTest.java
+++ b/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/util/http/HttpUtilTest.java
@@ -59,7 +59,7 @@ public class HttpUtilTest {
     /**
      *
      */
-    private static final Integer TEST_SERVER_PORT = 1234;
+    private static final Integer TEST_SERVER_PORT = 11234;
 
     /**
      *


### PR DESCRIPTION
Port 1234 is used by many of our docker setups, which leads to conflicts when building/testing shogun-core while docker is running.
This will simply change the port from 1234 to 11234