### PR TITLE
Add geoserver.action that does not forward headers

### DIFF
--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/service/GeoServerInterceptorService.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/service/GeoServerInterceptorService.java
@@ -103,10 +103,10 @@ public class GeoServerInterceptorService {
      * @throws HttpException
      * @throws IOException
      */
-    public Response interceptGeoServerRequest( HttpServletRequest request )
+    public Response interceptGeoServerRequest( HttpServletRequest request, boolean forwardHeaders )
         throws InterceptorException, URISyntaxException,
         HttpException, IOException {
-        return interceptGeoServerRequest( request, Optional.empty() );
+        return interceptGeoServerRequest( request, Optional.empty(), forwardHeaders );
     }
 
     /**
@@ -118,7 +118,7 @@ public class GeoServerInterceptorService {
      * @throws HttpException
      * @throws IOException
      */
-    public Response interceptGeoServerRequest( HttpServletRequest request, Optional<String> endpoint )
+    public Response interceptGeoServerRequest( HttpServletRequest request, Optional<String> endpoint, boolean forwardHeaders )
         throws InterceptorException, URISyntaxException,
         HttpException, IOException {
 
@@ -148,7 +148,7 @@ public class GeoServerInterceptorService {
 
         // send the request
         // TODO: Move to global proxy class
-        Response response = sendRequest(mutableRequest);
+        Response response = sendRequest(mutableRequest, forwardHeaders);
 
         // intercept the response (if needed)
         Response interceptedResponse = ogcMessageDistributor
@@ -492,7 +492,7 @@ public class GeoServerInterceptorService {
      * @throws InterceptorException
      * @throws HttpException
      */
-    public static Response sendRequest(MutableHttpServletRequest request)
+    public static Response sendRequest(MutableHttpServletRequest request, boolean forwardHeaders)
         throws InterceptorException, HttpException {
 
         Response httpResponse = new Response();
@@ -506,7 +506,10 @@ public class GeoServerInterceptorService {
             // get the request URI
             URI requestUri = new URI(request.getRequestURI());
 
-            Header[] requestHeaders = getRequestHeadersToForward(request);
+            Header[] requestHeaders = {};
+            if (forwardHeaders) {
+                requestHeaders = getRequestHeadersToForward(request);
+            }
 
             // get the query parameters provided by the GET/POST request and
             // convert to a list of NameValuePairs

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/web/GeoServerInterceptorController.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/web/GeoServerInterceptorController.java
@@ -59,7 +59,48 @@ public class GeoServerInterceptorController<S extends GeoServerInterceptorServic
         try {
             LOG.trace("Trying to intercept a GeoServer resource.");
 
-            httpResponse = this.service.interceptGeoServerRequest(request, endpoint);
+            httpResponse = this.service.interceptGeoServerRequest(request, endpoint, true);
+
+            responseStatus = httpResponse.getStatusCode();
+            responseBody = httpResponse.getBody();
+            responseHeaders = httpResponse.getHeaders();
+
+            LOG.trace("Successfully intercepted a GeoServer resource.");
+
+            return new ResponseEntity<byte[]>(responseBody,
+                responseHeaders, responseStatus);
+
+        } catch (Exception e) {
+            LOG.error(ERROR_MESSAGE + e.getMessage());
+
+            responseHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+            Map<String, Object> responseMsg = ResultSet.error(
+                ERROR_MESSAGE + e.getMessage());
+
+            return new ResponseEntity<Map<String, Object>>(responseMsg,
+                responseHeaders, responseStatus);
+        }
+
+    }
+
+    /**
+     * A geoserver.action endpoint that does not pass headers such as Basic Authorization headers
+     *
+     * @param request
+     */
+    @RequestMapping(value = {"/geoserver-noauth.action", "/geoserver-noauth.action/{endpoint}"}, method = {
+        RequestMethod.GET, RequestMethod.POST})
+    public ResponseEntity<?> interceptGeoServerRequestWithoutAuth( HttpServletRequest request, @PathVariable(value="endpoint", required = false) Optional<String> endpoint ) {
+        HttpHeaders responseHeaders = new HttpHeaders();
+        HttpStatus responseStatus = HttpStatus.OK;
+        byte[] responseBody = null;
+        Response httpResponse = null;
+
+        try {
+            LOG.trace("Trying to intercept a GeoServer resource.");
+
+            httpResponse = this.service.interceptGeoServerRequest(request, endpoint, false);
 
             responseStatus = httpResponse.getStatusCode();
             responseBody = httpResponse.getBody();

--- a/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/service/GeoServerInterceptorServiceTest.java
+++ b/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/service/GeoServerInterceptorServiceTest.java
@@ -72,7 +72,7 @@ public class GeoServerInterceptorServiceTest {
     public void test_throws_on_non_ogc_request() throws InterceptorException,
         URISyntaxException, HttpException, IOException {
         MockHttpServletRequest httpRequest = new MockHttpServletRequest();
-        gsInterceptorService.interceptGeoServerRequest(httpRequest);
+        gsInterceptorService.interceptGeoServerRequest(httpRequest, true);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class GeoServerInterceptorServiceTest {
         when(ruleService.findAllRulesForServiceAndEvent(
             any(String.class), any(String.class))).thenReturn(
             getTestInterceptorRulesForServiceAndEvent("WMS", "REQUEST"));
-        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest);
+        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest, true);
         assertEquals(resp, got);
     }
 
@@ -132,7 +132,7 @@ public class GeoServerInterceptorServiceTest {
             any(String.class), any(String.class))).thenReturn(
             getTestInterceptorRulesForServiceAndEvent("WMS", "REQUEST"));
 
-        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest);
+        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest, true);
 
         assertEquals(resp, got);
     }
@@ -166,7 +166,7 @@ public class GeoServerInterceptorServiceTest {
             any(String.class), any(String.class))).thenReturn(
             getTestInterceptorRulesForServiceAndEvent("WMS", "REQUEST"));
 
-        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest);
+        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest, true);
 
         assertEquals(resp, got);
 
@@ -208,7 +208,7 @@ public class GeoServerInterceptorServiceTest {
             any(String.class), any(String.class))).thenReturn(
             getTestInterceptorRulesForServiceAndEvent("WMS", "REQUEST"));
 
-        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest);
+        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest, true);
 
         assertEquals(resp, got);
     }
@@ -252,7 +252,7 @@ public class GeoServerInterceptorServiceTest {
             any(String.class), any(String.class))).thenReturn(
             getTestInterceptorRulesForServiceAndEvent("WFS", "REQUEST"));
 
-        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest);
+        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest, true);
 
         assertEquals(resp, got);
     }
@@ -303,7 +303,7 @@ public class GeoServerInterceptorServiceTest {
             any(String.class), any(String.class))).thenReturn(
             getTestInterceptorRulesForServiceAndEvent("WFS", "REQUEST"));
 
-        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest);
+        Response got = gsInterceptorService.interceptGeoServerRequest(httpRequest, true);
 
         assertEquals(resp, got);
 

--- a/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/web/GeoServerInterceptorControllerTest.java
+++ b/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/web/GeoServerInterceptorControllerTest.java
@@ -57,7 +57,8 @@ public class GeoServerInterceptorControllerTest {
 
         Mockito.when(geoServerInterceptorService.interceptGeoServerRequest(
             Matchers.any(HttpServletRequest.class),
-            Matchers.any(Optional.class)
+            Matchers.any(Optional.class),
+            Matchers.any(boolean.class)
         )).thenReturn(responseObject);
 
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get(INTERCEPTOR_ENDPOINT))
@@ -75,7 +76,8 @@ public class GeoServerInterceptorControllerTest {
 
         Mockito.when(geoServerInterceptorService.interceptGeoServerRequest(
             Matchers.any(HttpServletRequest.class),
-            Matchers.any(Optional.class)
+            Matchers.any(Optional.class),
+            Matchers.any(boolean.class)
         )).thenReturn(responseObject);
 
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post(INTERCEPTOR_ENDPOINT))
@@ -92,7 +94,8 @@ public class GeoServerInterceptorControllerTest {
         Response responseObject = new Response(HttpStatus.OK, responseHeaders, testString.getBytes());
 
         Mockito.when(geoServerInterceptorService.interceptGeoServerRequest(
-            Matchers.any(HttpServletRequest.class)
+            Matchers.any(HttpServletRequest.class),
+            Matchers.any(boolean.class)
         )).thenReturn(responseObject);
 
         /**
@@ -105,7 +108,8 @@ public class GeoServerInterceptorControllerTest {
     @Test
     public void returnsErrorObjectIfExceptionWasThrown() throws Exception {
         Mockito.when(geoServerInterceptorService.interceptGeoServerRequest(
-            Matchers.any(HttpServletRequest.class)
+            Matchers.any(HttpServletRequest.class),
+            Matchers.any(boolean.class)
         )).thenThrow(InterceptorException.class);
 
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get(INTERCEPTOR_ENDPOINT))


### PR DESCRIPTION
This adds an additional `geoserver-noauth.action` which does not pass headers to the geoserver. The normal `geoserver.action` forwards Basic Authentication headers.

This is breaking requests authenticating via basic auth (to SHOGun) because it sends the same credentials to the geoserver. Even if the geoserver is not secured it refuses these requests.

@terrestris/devs Please review
