### PR TITLE
Geoserver interceptor: Add setting which allows to ignore namespaces

### DIFF
--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/converter/PersistentObjectIdResolver.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/converter/PersistentObjectIdResolver.java
@@ -28,7 +28,7 @@ public abstract class PersistentObjectIdResolver<E extends PersistentObject, D e
     /**
      * Default Constructor that injects beans automatically.
      */
-    PersistentObjectIdResolver() {
+    public PersistentObjectIdResolver() {
         // As subclasses of this class are used in the resolver property of an
         // JsonIdentityInfo annotation, we cannot easily autowire components
         // (like the service for the current). For that reason, we use this

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/init/ContentInitializer.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/init/ContentInitializer.java
@@ -22,7 +22,7 @@ public class ContentInitializer {
     /**
      * The Logger
      */
-    protected static final Logger logger = getLogger(ContentInitializer.class);
+    protected final Logger logger = getLogger(getClass());
     /**
      * Initialization Service to init shogun content like users or default
      * applications.

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/service/GeoServerInterceptorService.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/service/GeoServerInterceptorService.java
@@ -21,6 +21,7 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
@@ -88,6 +89,12 @@ public class GeoServerInterceptorService {
      * topp=http://localhost:8080/geoserver/topp/ows
      */
     private Properties geoServerNameSpaces;
+
+    @Value("${geoserver.interceptor.namespaceBoundUrl:true}")
+    private boolean namespaceBoundUrl;
+
+    @Value("${geoserver.interceptor.defaultOwsUrl:}")
+    private String defaultOwsUrl;
 
     /**
      * @param params
@@ -623,8 +630,14 @@ public class GeoServerInterceptorService {
 
         URI uri = null;
 
-        String geoServerUrl = this.geoServerNameSpaces.getProperty(
-            geoServerNamespace);
+        String geoServerUrl;
+        if (namespaceBoundUrl) {
+            geoServerUrl = this.geoServerNameSpaces.getProperty(
+                geoServerNamespace);
+        } else {
+            geoServerUrl = defaultOwsUrl;
+            LOG.debug("Using GeoServer OWS URL without namespace: {}" , geoServerUrl);
+        }
 
         if (StringUtils.isEmpty(geoServerUrl)) {
             throw new InterceptorException("Couldn't detect GeoServer URI " +

--- a/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/service/GeoServerInterceptorServiceTest.java
+++ b/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/service/GeoServerInterceptorServiceTest.java
@@ -28,6 +28,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -62,6 +63,7 @@ public class GeoServerInterceptorServiceTest {
     @Before
     public void setUp() throws IOException {
         MockitoAnnotations.initMocks(this);
+        ReflectionTestUtils.setField(gsInterceptorService, "namespaceBoundUrl", true);
 
         Properties geoServerNameSpaces = new Properties();
         geoServerNameSpaces.setProperty("bvb", TEST_GEOSERVER_BASE_PATH + "bvb/ows");


### PR DESCRIPTION
Introduces the property `geoserver.interceptor.namespaceBoundUrl`. When set to false, the geoserver interceptor will instead use a namespace-less url provided in `geoserver.interceptor.defaultOwsUrl`
This can be useful if you want to access all geoserver namespaces, not just one.

Since the default value for `geoserver.interceptor.namespaceBoundUrl` is true, this will not change the behavior in existing projects.

Small bugfix: Makes PersistentObjectIdResolver constructor public because it was protected by default and the class could not be extended because of this.

@devs Please review