### PR TITLE
Introduces CreatedHelper

### DIFF
--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/helper/CreatedHelper.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/helper/CreatedHelper.java
@@ -1,0 +1,44 @@
+package de.terrestris.shoguncore.helper;
+
+import de.terrestris.shoguncore.model.PersistentObject;
+import org.apache.logging.log4j.Logger;
+import org.joda.time.ReadableDateTime;
+
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import static org.apache.logging.log4j.LogManager.getLogger;
+
+public class CreatedHelper {
+
+    private static final Logger logger = getLogger(IdHelper.class);
+
+    /**
+     * Helper method that uses reflection to set the (inaccessible) created field of
+     * the given {@link PersistentObject}.
+     *
+     * @param persistentObject The object with the inaccessible created field
+     * @param created               The created datetime to set
+     * @throws NoSuchFieldException
+     * @throws IllegalAccessException
+     */
+    public static final void setCreatedOnPersistentObject(
+        PersistentObject persistentObject, ReadableDateTime created)
+        throws NoSuchFieldException, IllegalAccessException {
+        // use reflection to get the inaccessible final field 'created'
+        Field createdField = PersistentObject.class.getDeclaredField("created");
+
+        AccessController.doPrivileged((PrivilegedAction<PersistentObject>) () -> {
+            createdField.setAccessible(true);
+            try {
+                createdField.set(persistentObject, created);
+            } catch (IllegalAccessException e) {
+                logger.error("Could not set CREATED field for persistent object", e);
+            }
+            createdField.setAccessible(false);
+            return null;
+        });
+
+    }
+}

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/helper/CreatedHelper.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/helper/CreatedHelper.java
@@ -12,7 +12,7 @@ import static org.apache.logging.log4j.LogManager.getLogger;
 
 public class CreatedHelper {
 
-    private static final Logger logger = getLogger(IdHelper.class);
+    private static final Logger logger = getLogger(CreatedHelper.class);
 
     /**
      * Helper method that uses reflection to set the (inaccessible) created field of


### PR DESCRIPTION
Adds a new helper class `CreatedHelper` that allows setting the created field on `PersistentObject`s.

This is needed for the future database performance improvements of shogun2webapp.

Please review @dnlkoch 