### PR TITLE
Enable usage of endpoints

### DIFF
--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/enumeration/OgcEnum.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/enumeration/OgcEnum.java
@@ -250,7 +250,8 @@ public class OgcEnum {
         LAYER("LAYER"),
         TYPENAME("TYPENAME"),
         TYPENAMES("TYPENAMES"),
-        NAMESPACE("NAMESPACE");
+        NAMESPACE("NAMESPACE"),
+        CUSTOM_ENDPOINT("CUSTOM_ENDPOINT");
 
         private final String value;
 


### PR DESCRIPTION
This enables e.g. requesting capabilities via http://localhost/shogun2-webapp/geoserver.action/SHOGUN?request=GetCapabilities&service=WMS

Instead of having to send a bogus `LAYERS` parameter this enables the use of the `geoserver.action` to actually work as a WMS endpoint e.g. or usage in qgis.

Prerequisite for correct URLs appearing in the capabilities document is that the headers `x-forwarded-proto` and `x-forwarded-host` are properly set in requests if behind a reverse proxy.

@terrestris/devs Please review.