### PR TITLE
Enhancing WMTS support

### DIFF
--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/model/layer/source/WmtsLayerDataSource.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/model/layer/source/WmtsLayerDataSource.java
@@ -30,7 +30,7 @@ public class WmtsLayerDataSource extends LayerDataSource {
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private WmtsTileGrid tileGrid;
 
-    @ElementCollection(targetClass = String.class)
+    @ElementCollection(targetClass = String.class, fetch = FetchType.EAGER)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private List<String> urls;
 
@@ -39,6 +39,7 @@ public class WmtsLayerDataSource extends LayerDataSource {
     private String projection;
     private String matrixSet;
     private String requestEncoding;
+    private String capabilitiesUrl;
 
     /**
      * Default constructor
@@ -56,7 +57,8 @@ public class WmtsLayerDataSource extends LayerDataSource {
      * @param requestEncoding
      * @param urls
      */
-    public WmtsLayerDataSource(WmtsTileGrid tileGrid, String wmtsLayer, String wmtsStyle, String projection, String matrixSet, String requestEncoding, List<String> urls) {
+    public WmtsLayerDataSource(WmtsTileGrid tileGrid, String wmtsLayer, String wmtsStyle, String projection,
+       String matrixSet, String requestEncoding, List<String> urls, String capabilitiesUrl) {
         this();
         this.tileGrid = tileGrid;
         this.wmtsLayer = wmtsLayer;
@@ -65,6 +67,7 @@ public class WmtsLayerDataSource extends LayerDataSource {
         this.matrixSet = matrixSet;
         this.requestEncoding = requestEncoding;
         this.urls = urls;
+        this.capabilitiesUrl = capabilitiesUrl;
     }
 
     /**
@@ -166,6 +169,22 @@ public class WmtsLayerDataSource extends LayerDataSource {
     }
 
     /**
+     *
+     * @return The capabilitiesUrl
+     */
+    public String getCapabilitiesUrl() {
+        return capabilitiesUrl;
+    }
+
+    /**
+     *
+     * @param capabilitiesUrl The capabilitiesUrl to set
+     */
+    public void setCapabilitiesUrl(String capabilitiesUrl) {
+        this.capabilitiesUrl = capabilitiesUrl;
+    }
+
+    /**
      * @see java.lang.Object#hashCode()
      * <p>
      * According to
@@ -184,6 +203,7 @@ public class WmtsLayerDataSource extends LayerDataSource {
             append(getWmtsStyle()).
             append(getTileGrid()).
             append(getUrls()).
+            append(getCapabilitiesUrl()).
             toHashCode();
     }
 
@@ -210,6 +230,7 @@ public class WmtsLayerDataSource extends LayerDataSource {
             append(getWmtsStyle(), other.getWmtsStyle()).
             append(getTileGrid(), other.getTileGrid()).
             append(getUrls(), other.getUrls()).
+            append(getCapabilitiesUrl(), other.getCapabilitiesUrl()).
             isEquals();
     }
 

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/OgcMessageDistributor.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/OgcMessageDistributor.java
@@ -7,8 +7,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.text.MessageFormat;
-import java.util.HashMap;
-import java.util.Optional;
 
 import static org.apache.logging.log4j.LogManager.getLogger;
 
@@ -133,34 +131,13 @@ public class OgcMessageDistributor {
     private WpsResponseInterceptorInterface wpsResponseInterceptor;
 
     /**
-     *
      * @param request
      * @param message
      * @return
      * @throws InterceptorException
      */
     public MutableHttpServletRequest distributeToRequestInterceptor(
-        MutableHttpServletRequest request,
-        OgcMessage message) throws InterceptorException {
-            return distributeToRequestInterceptor(
-                request,
-                message,
-                new HashMap<String, Optional<String>>()
-            );
-    }
-
-    /**
-     * @param request
-     * @param message
-     * @param optionals
-     * @return
-     * @throws InterceptorException
-     */
-    public MutableHttpServletRequest distributeToRequestInterceptor(
-        MutableHttpServletRequest request,
-        OgcMessage message,
-        HashMap<String, Optional<String>> optionals)
-        throws InterceptorException {
+        MutableHttpServletRequest request, OgcMessage message) throws InterceptorException {
 
         if (message.isRequestAllowed()) {
             LOG.debug("Request is ALLOWED, not intercepting the request.");
@@ -218,13 +195,9 @@ public class OgcMessageDistributor {
             if (message.isWmtsGetCapabilities()) {
                 request = this.wmtsRequestInterceptor.interceptGetCapabilities(request);
             } else if (message.isWmtsGetTile()) {
-                request = this.wmtsRequestInterceptor.interceptGetTile(
-                    request,
-                    optionals);
+                request = this.wmtsRequestInterceptor.interceptGetTile(request);
             } else if (message.isWmtsGetFeatureInfo()) {
-                request = this.wmtsRequestInterceptor.interceptGetFeatureInfo(
-                    request,
-                    optionals);
+                request = this.wmtsRequestInterceptor.interceptGetFeatureInfo(request);
             } else {
                 throw new InterceptorException(operationErrMsg);
             }

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/WmtsRequestInterceptorInterface.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/WmtsRequestInterceptorInterface.java
@@ -1,17 +1,14 @@
 package de.terrestris.shoguncore.util.interceptor;
 
-import java.util.HashMap;
-import java.util.Optional;
-
 import org.springframework.stereotype.Component;
 
 @Component
 public interface WmtsRequestInterceptorInterface {
 
-    MutableHttpServletRequest interceptGetTile(MutableHttpServletRequest request, HashMap<String, Optional<String>> optionals);
+    MutableHttpServletRequest interceptGetTile(MutableHttpServletRequest request);
 
     MutableHttpServletRequest interceptGetCapabilities(MutableHttpServletRequest request);
 
-    MutableHttpServletRequest interceptGetFeatureInfo(MutableHttpServletRequest request, HashMap<String, Optional<String>> optionals);
+    MutableHttpServletRequest interceptGetFeatureInfo(MutableHttpServletRequest request);
 
 }

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/WmtsUtil.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/WmtsUtil.java
@@ -1,6 +1,5 @@
 package de.terrestris.shoguncore.util.interceptor;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Locale;
@@ -26,12 +25,10 @@ public class WmtsUtil {
      */
     public static boolean isRestfulWmtsRequest(MutableHttpServletRequest mutableRequest) {
         String url = mutableRequest.getRequestURL().toString();
-        String service = mutableRequest.getParameterIgnoreCase("service");
-        if (!StringUtils.isEmpty(service) && service.equalsIgnoreCase("wmts")) {
-            // looks like KVP
-            return false;
-        }
-        return Pattern.compile(".*/geoserver.action/.*/wmts/\\d+/(.*)").matcher(url).matches();
+        // check for presence of tilematrixset, tilematrix, tilecol and tilerow
+        boolean defaultRestfulRequest = Pattern.compile("[^\\/]*\\/[^\\/]*[^\\/]\\/\\d+\\/\\d+").matcher(url).find();
+        boolean isWmtsUrl = Pattern.compile(".*/geoserver.action/.*/wmts/\\d+/(.*)").matcher(url).matches();
+        return defaultRestfulRequest && isWmtsUrl;
     }
 
     /**
@@ -46,7 +43,7 @@ public class WmtsUtil {
         String url = mutableRequest.getRequestURL().toString();
         // weak test if we have at least 4 digits in the path for tilecol, tilerow, i and j
         return !isRestfulWmtsGetTile(mutableRequest) &&
-            Pattern.compile("\\/\\d+\\/\\d+\\/\\d+\\/\\d+").matcher(url).matches();
+            Pattern.compile("\\/\\d+\\/\\d+\\/\\d+\\/\\d+").matcher(url).find();
     }
 
     /**

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/WmtsUtil.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/WmtsUtil.java
@@ -1,0 +1,90 @@
+package de.terrestris.shoguncore.util.interceptor;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import static org.apache.logging.log4j.LogManager.getLogger;
+
+/**
+ * @author Johannes Weskamm
+ * @author terrestris GmbH & Co. KG
+ */
+public class WmtsUtil {
+
+    /**
+     * The Logger.
+     */
+    private static final Logger LOG = getLogger(WmtsUtil.class);
+
+    /**
+     * Check if given request is a RESTful WMTS call
+     * @param mutableRequest
+     * @return
+     */
+    public static boolean isRestfulWmtsRequest(MutableHttpServletRequest mutableRequest) {
+        String url = mutableRequest.getRequestURL().toString();
+        String service = mutableRequest.getParameterIgnoreCase("service");
+        if (!StringUtils.isEmpty(service) && service.equalsIgnoreCase("wmts")) {
+            // looks like KVP
+            return false;
+        }
+        return Pattern.compile(".*/geoserver.action/.*/wmts/\\d+/(.*)").matcher(url).matches();
+    }
+
+    /**
+     * Check if given request is a RESTful GetFeatureInfo call
+     * @param mutableRequest
+     * @return
+     */
+    public static boolean isRestfulWmtsGetFeatureinfo(MutableHttpServletRequest mutableRequest) {
+        if (!isRestfulWmtsRequest(mutableRequest)) {
+            return false;
+        }
+        String url = mutableRequest.getRequestURL().toString();
+        // weak test if we have at least 4 digits in the path for tilecol, tilerow, i and j
+        return !isRestfulWmtsGetTile(mutableRequest) &&
+            Pattern.compile("\\/\\d+\\/\\d+\\/\\d+\\/\\d+").matcher(url).matches();
+    }
+
+    /**
+     * Check if given request is a RESTful GetTile call
+     * @param mutableRequest
+     * @return
+     */
+    public static boolean isRestfulWmtsGetTile(MutableHttpServletRequest mutableRequest) {
+        if (!isRestfulWmtsRequest(mutableRequest)) {
+            return false;
+        }
+        String url = mutableRequest.getRequestURL().toString();
+        String format = mutableRequest.getParameterIgnoreCase("format");
+        if (format == null) {
+            if (url.endsWith(".png") ||
+                url.endsWith(".jpg") ||
+                url.endsWith(".jpeg") ||
+                url.endsWith(".gif")) {
+                return true;
+            }
+        } else if (format.toLowerCase(Locale.ROOT).contains("image")) {
+            // GeoServer way of handling image format in RESTful requests
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Return the layer id for the given request
+     * @param mutableRequest
+     * @return
+     */
+    public static String getLayerId(MutableHttpServletRequest mutableRequest) {
+        try {
+            String part = mutableRequest.getRequestURL().toString().split("/wmts/")[1];
+            return part.split("/")[0];
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/secure/WmtsResponseInterceptor.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/secure/WmtsResponseInterceptor.java
@@ -4,24 +4,29 @@ import de.terrestris.shoguncore.dao.LayerDao;
 import de.terrestris.shoguncore.model.layer.Layer;
 import de.terrestris.shoguncore.model.layer.source.WmtsLayerDataSource;
 import de.terrestris.shoguncore.service.LayerService;
+import de.terrestris.shoguncore.util.http.HttpUtil;
 import de.terrestris.shoguncore.util.interceptor.MutableHttpServletRequest;
 import de.terrestris.shoguncore.util.interceptor.WmtsResponseInterceptorInterface;
 import de.terrestris.shoguncore.util.model.Response;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpException;
 import org.apache.logging.log4j.Logger;
 import org.deegree.commons.xml.CommonNamespaces;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 import javax.transaction.Transactional;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -29,6 +34,8 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.*;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -69,11 +76,16 @@ public class WmtsResponseInterceptor implements WmtsResponseInterceptorInterface
 
         // get all layers allowed for this user in order to filter out not allowed ones
         List<Layer> layers = layerService.findAll();
+        List<Layer> externalLayers = new ArrayList<Layer>();
         List<String> layerNames = new ArrayList<String>();
         for (Layer layer : layers) {
             if (layer.getSource() instanceof WmtsLayerDataSource) {
                 WmtsLayerDataSource source = (WmtsLayerDataSource) layer.getSource();
-                layerNames.add(source.getWmtsLayer());
+                if (source.getUrl().contains("geoserver.action")) {
+                    layerNames.add(source.getWmtsLayer());
+                } else {
+                    externalLayers.add(layer);
+                }
             }
         }
 
@@ -91,9 +103,14 @@ public class WmtsResponseInterceptor implements WmtsResponseInterceptorInterface
             if (StringUtils.isEmpty(host)) {
                 host = request.getServerName();
             }
-            String baseUrl = proto + "://" + host + request.getParameter("CONTEXT_PATH") + "/geoserver.action/" + endpoint;
+            String baseUrl = proto + "://" + host + request.getParameter("CONTEXT_PATH") + "/geoserver.action/" +
+                endpoint;
             removeLayers(doc, "wmts", layerNames);
+            for (Layer layer : externalLayers) {
+                addExternalLayer(doc, layer);
+            }
             updateUrls(doc, "wmts", baseUrl);
+            removeOperations(doc);
 
             Transformer transformer = TransformerFactory.newInstance().newTransformer();
             DOMSource source = new DOMSource(doc);
@@ -220,9 +237,97 @@ public class WmtsResponseInterceptor implements WmtsResponseInterceptorInterface
                 String path = url.split("gwc/service/wmts/rest")[1];
                 url = baseUrl + path;
                 nodeList2.item(i).setNodeValue(url);
-            } else {
+            } else if (url.indexOf("geoserver.action") < 0) {
                 nodeList2.item(i).setNodeValue(baseUrl);
             }
+        }
+    }
+
+    /**
+     * Add external Layers and their TileMatrixSets to the document
+     * @param doc
+     * @param layer
+     */
+    private void addExternalLayer(Document doc, Layer layer) {
+        WmtsLayerDataSource source = (WmtsLayerDataSource) layer.getSource();
+        String externalCapabilities = source.getCapabilitiesUrl();
+        if (StringUtils.isEmpty(externalCapabilities)) {
+            return;
+        }
+        try {
+            Response response = HttpUtil.get(externalCapabilities);
+            byte[] body = response.getBody();
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document externalDoc = builder.parse(new ByteArrayInputStream(body));
+
+            XPathFactory xfactory = XPathFactory.newInstance();
+            XPath xpath = xfactory.newXPath();
+            String owsVersion = externalDoc.getDocumentElement().getAttribute("xmlns:ows");
+            String wmtsVersion = externalDoc.getDocumentElement().getAttribute("xmlns");
+            NamespaceContext nscontext = CommonNamespaces.getNamespaceContext().
+                addNamespace("ows", owsVersion).
+                addNamespace("wmts", wmtsVersion);
+            xpath.setNamespaceContext(nscontext);
+            String expressionString = "//wmts:Contents/wmts:Layer[ows:Identifier='" +
+                ((WmtsLayerDataSource) layer.getSource()).getWmtsLayer() + "']";
+            XPathExpression expr = xpath.compile(expressionString);
+            NodeList nodeList = (NodeList) expr.evaluate(externalDoc, XPathConstants.NODESET);
+            Element contentNode = (Element) xpath.compile(
+                "//wmts:Contents").evaluate(doc, XPathConstants.NODE);
+            for (int i = 0; i < nodeList.getLength(); ++i) {
+                // add the layer entry
+                Element el = (Element) nodeList.item(i);
+                NodeList resourceUrls = (NodeList) el.getElementsByTagName("ResourceURL");
+                for (int j = 0; j < nodeList.getLength(); ++j) {
+                    resourceUrls.item(j).getAttributes().getNamedItem("template")
+                        .setNodeValue(source.getUrls().get(0));
+                }
+
+                Node importedNode = doc.importNode(el, true);
+                contentNode.appendChild(importedNode);
+
+                // add connected tilematrixsets
+                NodeList tmsList = (NodeList) xpath.compile("//wmts:Contents/wmts:TileMatrixSet").
+                    evaluate(el, XPathConstants.NODESET);
+                for (int j = 0; j < tmsList.getLength(); ++j) {
+                    Node set = tmsList.item(j);
+                    Node importedTmsNode = doc.importNode(set, true);
+                    contentNode.appendChild(importedTmsNode);
+                }
+            }
+        } catch (ParserConfigurationException | SAXException | IOException | HttpException | XPathExpressionException |
+            URISyntaxException e) {
+            LOG.warn("Something went wrong when intercepting an external get capabilities response: " + e.getMessage());
+            LOG.trace("Stack trace", e);
+        }
+    }
+
+    /**
+     * Remove the Operations (KVP or RESTful support indicator) block from the capabilities document,
+     * so that clients use the template URLs to determine the request type
+     * @param doc
+     */
+    private void removeOperations(Document doc) {
+        XPathFactory factory = XPathFactory.newInstance();
+        XPath xpath = factory.newXPath();
+        String owsVersion = doc.getDocumentElement().getAttribute("xmlns:ows");
+        String wmtsVersion = doc.getDocumentElement().getAttribute("xmlns");
+        NamespaceContext nscontext = CommonNamespaces.getNamespaceContext().
+            addNamespace("ows", owsVersion).
+            addNamespace("wmts", wmtsVersion);
+        xpath.setNamespaceContext(nscontext);
+        try {
+            XPathExpression expr = xpath.compile("//ows:OperationsMetadata");
+            NodeList nodeList = (NodeList) expr.evaluate(doc, XPathConstants.NODESET);
+            for (int i = 0; i < nodeList.getLength(); ++i) {
+                // add the layer entry
+                Element el = (Element) nodeList.item(i);
+                el.getParentNode().removeChild(el);
+            }
+        } catch (XPathExpressionException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/secure/WmtsResponseInterceptor.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/secure/WmtsResponseInterceptor.java
@@ -256,6 +256,9 @@ public class WmtsResponseInterceptor implements WmtsResponseInterceptorInterface
         }
         try {
             Response response = HttpUtil.get(externalCapabilities);
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                return;
+            }
             byte[] body = response.getBody();
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
@@ -300,7 +303,7 @@ public class WmtsResponseInterceptor implements WmtsResponseInterceptorInterface
         } catch (ParserConfigurationException | SAXException | IOException | HttpException | XPathExpressionException |
             URISyntaxException e) {
             LOG.warn("Something went wrong when intercepting an external get capabilities response: " + e.getMessage());
-            LOG.trace("Stack trace", e);
+            LOG.trace("Full stack trace: ", e);
         }
     }
 

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/web/GeoServerInterceptorController.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/web/GeoServerInterceptorController.java
@@ -21,7 +21,6 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -78,25 +77,11 @@ public class GeoServerInterceptorController<S extends GeoServerInterceptorServic
     /**
      * @param request
      */
-    @RequestMapping(value = {
-        "/geoserver.action",
-        "/geoserver.action/{endpoint}",
-        "/geoserver.action/{endpoint}/{layername}/{style}/{tilematrixset}/{tilematrix}/{tilerow}/{tilecol}",
-        "/geoserver.action/{endpoint}/{layername}/{style}/{tilematrixset}/{tilematrix}/{tilerow}/{tilecol}/{j}/{i}"
-    }, method = {
-        RequestMethod.GET, RequestMethod.POST
-    })
+    @RequestMapping(value = {"/geoserver.action", "/geoserver.action/{endpoint}/**"}, method = {
+        RequestMethod.GET, RequestMethod.POST})
     public ResponseEntity<?> interceptGeoServerRequest(
         HttpServletRequest request,
-        @PathVariable(value = "endpoint", required = false) Optional<String> endpoint,
-        @PathVariable(value = "layername", required = false) Optional<String> layername,
-        @PathVariable(value = "style", required = false) Optional<String> style,
-        @PathVariable(value = "tilematrixset", required = false) Optional<String> tilematrixset,
-        @PathVariable(value = "tilematrix", required = false) Optional<String> tilematrix,
-        @PathVariable(value = "tilerow", required = false) Optional<String> tilerow,
-        @PathVariable(value = "tilecol", required = false) Optional<String> tilecol,
-        @PathVariable(value = "j", required = false) Optional<String> j,
-        @PathVariable(value = "i", required = false) Optional<String> i
+        @PathVariable(value = "endpoint", required = false) Optional<String> endpoint
     ) {
         HttpHeaders responseHeaders = new HttpHeaders();
         HttpStatus responseStatus = HttpStatus.OK;
@@ -106,19 +91,7 @@ public class GeoServerInterceptorController<S extends GeoServerInterceptorServic
         try {
             LOG.trace("Trying to intercept a GeoServer resource.");
 
-            HashMap<String, Optional<String>> optionals = new HashMap<String, Optional<String>>();
-            optionals.put("endpoint", endpoint);
-            optionals.put("layername", layername);
-            optionals.put("style", style);
-            optionals.put("tilematrixset", tilematrixset);
-            optionals.put("tilematrix", tilematrix);
-            optionals.put("tilerow", tilerow);
-            optionals.put("tilecol", tilecol);
-            optionals.put("j", j);
-            optionals.put("i", i);
-
-            httpResponse = this.service.interceptGeoServerRequest(
-                request, optionals);
+            httpResponse = this.service.interceptGeoServerRequest(request, endpoint);
 
             responseStatus = httpResponse.getStatusCode();
             responseBody = httpResponse.getBody();

--- a/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/service/GeoServerInterceptorServiceTest.java
+++ b/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/service/GeoServerInterceptorServiceTest.java
@@ -36,7 +36,6 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 
@@ -97,7 +96,7 @@ public class GeoServerInterceptorServiceTest {
         MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
 
         when(ogcMessageDistributor.distributeToRequestInterceptor(
-            any(MutableHttpServletRequest.class), any(OgcMessage.class), any(HashMap.class))).thenReturn(mutableRequest);
+            any(MutableHttpServletRequest.class), any(OgcMessage.class))).thenReturn(mutableRequest);
 
         when(ogcMessageDistributor.distributeToResponseInterceptor(
             any(MutableHttpServletRequest.class), any(Response.class), any(OgcMessage.class))).thenReturn(resp);
@@ -126,7 +125,7 @@ public class GeoServerInterceptorServiceTest {
         MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
 
         when(ogcMessageDistributor.distributeToRequestInterceptor(
-            any(MutableHttpServletRequest.class), any(OgcMessage.class), any(HashMap.class))).thenReturn(mutableRequest);
+            any(MutableHttpServletRequest.class), any(OgcMessage.class))).thenReturn(mutableRequest);
 
         when(ogcMessageDistributor.distributeToResponseInterceptor(
             any(MutableHttpServletRequest.class), any(Response.class), any(OgcMessage.class))).thenReturn(resp);
@@ -160,7 +159,7 @@ public class GeoServerInterceptorServiceTest {
         MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
 
         when(ogcMessageDistributor.distributeToRequestInterceptor(
-            any(MutableHttpServletRequest.class), any(OgcMessage.class), any(HashMap.class))).thenReturn(mutableRequest);
+            any(MutableHttpServletRequest.class), any(OgcMessage.class))).thenReturn(mutableRequest);
 
         when(ogcMessageDistributor.distributeToResponseInterceptor(
             any(MutableHttpServletRequest.class), any(Response.class), any(OgcMessage.class))).thenReturn(resp);
@@ -201,7 +200,7 @@ public class GeoServerInterceptorServiceTest {
         MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
 
         when(ogcMessageDistributor.distributeToRequestInterceptor(
-            any(MutableHttpServletRequest.class), any(OgcMessage.class), any(HashMap.class))).thenReturn(mutableRequest);
+            any(MutableHttpServletRequest.class), any(OgcMessage.class))).thenReturn(mutableRequest);
 
         // for the next stub it would be even better if we could use .then(returnsFirstArg() but this needs java 8
         when(ogcMessageDistributor.distributeToResponseInterceptor(
@@ -245,7 +244,7 @@ public class GeoServerInterceptorServiceTest {
         MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
 
         when(ogcMessageDistributor.distributeToRequestInterceptor(
-            any(MutableHttpServletRequest.class), any(OgcMessage.class), any(HashMap.class))).thenReturn(mutableRequest);
+            any(MutableHttpServletRequest.class), any(OgcMessage.class))).thenReturn(mutableRequest);
 
         // for the next stub it would be even better if we could use .then(returnsFirstArg() but this needs java 8
         when(ogcMessageDistributor.distributeToResponseInterceptor(
@@ -297,7 +296,7 @@ public class GeoServerInterceptorServiceTest {
         MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
 
         when(ogcMessageDistributor.distributeToRequestInterceptor(
-            any(MutableHttpServletRequest.class), any(OgcMessage.class), any(HashMap.class))).thenReturn(mutableRequest);
+            any(MutableHttpServletRequest.class), any(OgcMessage.class))).thenReturn(mutableRequest);
 
         when(ogcMessageDistributor.distributeToResponseInterceptor(
             any(MutableHttpServletRequest.class), any(Response.class), any(OgcMessage.class))).thenReturn(resp);

--- a/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/web/GeoServerInterceptorControllerTest.java
+++ b/src/shogun-core-main/src/test/java/de/terrestris/shoguncore/web/GeoServerInterceptorControllerTest.java
@@ -20,7 +20,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import javax.servlet.http.HttpServletRequest;
 
-import java.util.HashMap;
 import java.util.Optional;
 
 import static de.terrestris.shoguncore.web.GeoServerInterceptorController.ERROR_MESSAGE;
@@ -59,7 +58,7 @@ public class GeoServerInterceptorControllerTest {
 
         Mockito.when(geoServerInterceptorService.interceptGeoServerRequest(
             Matchers.any(HttpServletRequest.class),
-            Matchers.any(HashMap.class)
+            Matchers.any(Optional.class)
         )).thenReturn(responseObject);
 
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get(INTERCEPTOR_ENDPOINT))
@@ -77,7 +76,7 @@ public class GeoServerInterceptorControllerTest {
 
         Mockito.when(geoServerInterceptorService.interceptGeoServerRequest(
             Matchers.any(HttpServletRequest.class),
-            Matchers.any(HashMap.class)
+            Matchers.any(Optional.class)
         )).thenReturn(responseObject);
 
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post(INTERCEPTOR_ENDPOINT))


### PR DESCRIPTION
This PR enhances the usability of WMTS Layers through the geoserver.action interface.
WMTS layers will not get cascaded in GeoServer anymore, instead we reroute them to the original resource after succesful legitmation check.

Some code for RESTful WMTS requests has been simplified due to the `random` nature of WMTS requests (no strict parameter ordering and occurence)

The `geoserver.action` interface can now be used to have a single endpoint for WMTS Capabilities. All WMTS layers in SHOGun will be written to a single Capabilities document in the `WmtsResponseInterceptor` class.

@devs please review