### PR TITLE
Fix WFS interceptor

### DIFF
--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/secure/WfsResponseInterceptor.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/secure/WfsResponseInterceptor.java
@@ -157,16 +157,15 @@ public class WfsResponseInterceptor implements WfsResponseInterceptorInterface {
             addNamespace("wfs", "http://www.opengis.net/wfs"));
         NodeList list = (NodeList) xpath.compile("//wfs:FeatureType/wfs:Name").evaluate(doc.getDocumentElement(), NODESET);
         List<Element> toRemove = new ArrayList<>();
-        for (int i = 0; i < list.getLength(); ++i) {
-            Element name = (Element) list.item(i);
-            String str = name.getTextContent();
-            if (!layerNames.contains(str)) {
-                toRemove.add((Element) name.getParentNode());
-            }
-        }
+        determineFeatureTypeNodesToRemove(layerNames, list, toRemove);
         xpath.setNamespaceContext(CommonNamespaces.getNamespaceContext().
             addNamespace("wfs", "http://www.opengis.net/wfs/2.0"));
         list = (NodeList) xpath.compile("//wfs:FeatureType/wfs:Name").evaluate(doc.getDocumentElement(), NODESET);
+        determineFeatureTypeNodesToRemove(layerNames, list, toRemove);
+        toRemove.forEach(element -> element.getParentNode().removeChild(element));
+    }
+
+    private void determineFeatureTypeNodesToRemove(List<String> layerNames, NodeList list, List<Element> toRemove) {
         for (int i = 0; i < list.getLength(); ++i) {
             Element name = (Element) list.item(i);
             String str = name.getTextContent();
@@ -174,7 +173,6 @@ public class WfsResponseInterceptor implements WfsResponseInterceptorInterface {
                 toRemove.add((Element) name.getParentNode());
             }
         }
-        toRemove.forEach(element -> element.getParentNode().removeChild(element));
     }
 
     @Override


### PR DESCRIPTION
Fixes the following issues

* use the custom endpoint/namespace prefix when rewriting URLs in `GetCapabilities` responses
* use the proper WFS 2.0 namespace when removing feature types from `GetCapabilities` responses

@terrestris/devs Please review.