### PR TITLE
Disable hibernate second level cache for TreeNodes children

### DIFF
--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/model/tree/TreeFolder.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/model/tree/TreeFolder.java
@@ -3,14 +3,15 @@
  */
 package de.terrestris.shoguncore.model.tree;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
-import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+import javax.persistence.Table;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * This class represents a (simple) composite {@link TreeNode}, i.e. a folder
@@ -40,7 +41,6 @@ public class TreeFolder extends TreeNode {
      */
     @OneToMany(mappedBy = "parentFolder")
     @OrderBy("index")
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private List<TreeNode> children = new ArrayList<TreeNode>();
 
     /**

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/model/tree/TreeNode.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/model/tree/TreeNode.java
@@ -3,18 +3,28 @@
  */
 package de.terrestris.shoguncore.model.tree;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import de.terrestris.shoguncore.converter.TreeFolderIdResolver;
 import de.terrestris.shoguncore.model.PersistentObject;
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-
-import javax.persistence.*;
 
 /**
  * A class representing a node in a tree. This class can be used for leaf nodes.


### PR DESCRIPTION
This proposes to disable the second level cache for the children of the `TreeNode` as Hibernate won't recognize changes in them and will return the older values always.

First test are very promising. 

Please review @terrestris/devs.