### PR TITLE
Fix some checks to support WPS in interceptor

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -129,7 +129,7 @@
         <spring-ldap.version>2.3.2.RELEASE</spring-ldap.version>
         <log4j.version>2.17.0</log4j.version>
         <slf4j.version>1.7.28</slf4j.version>
-        <jackson.version>2.13.4.2</jackson.version>
+        <jackson.version>2.14.3</jackson.version>
         <opencsv.version>4.6</opencsv.version>
         <ehcache.version>3.8.1</ehcache.version>
 

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/service/GeoServerInterceptorService.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/service/GeoServerInterceptorService.java
@@ -152,7 +152,7 @@ public class GeoServerInterceptorService {
         // return the endPoint as nameSpace per default
         String geoServerNamespace = endPoint;
 
-        if (endPoint.contains(":")) {
+        if (endPoint != null && endPoint.contains(":")) {
             String[] split = endPoint.split(":");
             geoServerNamespace = split[0];
         }
@@ -510,7 +510,10 @@ public class GeoServerInterceptorService {
         if (StringUtils.isEmpty(requestService) ||
             StringUtils.isEmpty(requestOperation) ||
             StringUtils.isEmpty(requestEndPoint)) {
-            if (!StringUtils.isEmpty(requestEndPoint) &&
+
+            if (StringUtils.isEmpty(requestEndPoint) && StringUtils.equals(requestService, "WPS")) {
+                LOG.trace("This is a WPS request.");
+            } else if (!StringUtils.isEmpty(requestEndPoint) &&
                 !StringUtils.isEmpty(MutableHttpServletRequest.getRequestParameterValue(
                     mutableRequest, USE_REFLECT_PARAM))
             ) {
@@ -522,6 +525,7 @@ public class GeoServerInterceptorService {
                     "parameters (SERVICE, REQUEST, ENDPOINT). Please check the " +
                     "validity of the request.");
             }
+
         }
 
         if (StringUtils.isNotEmpty(requestService)) {

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/service/GeoServerInterceptorService.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/service/GeoServerInterceptorService.java
@@ -510,9 +510,8 @@ public class GeoServerInterceptorService {
         if (StringUtils.isEmpty(requestService) ||
             StringUtils.isEmpty(requestOperation) ||
             StringUtils.isEmpty(requestEndPoint)) {
-
             if (StringUtils.isEmpty(requestEndPoint) && StringUtils.equals(requestService, "WPS")) {
-                LOG.trace("This is a WPS request.");
+                LOG.trace("Will use empty string as endpoint for WPS");
             } else if (!StringUtils.isEmpty(requestEndPoint) &&
                 !StringUtils.isEmpty(MutableHttpServletRequest.getRequestParameterValue(
                     mutableRequest, USE_REFLECT_PARAM))
@@ -525,7 +524,6 @@ public class GeoServerInterceptorService {
                     "parameters (SERVICE, REQUEST, ENDPOINT). Please check the " +
                     "validity of the request.");
             }
-
         }
 
         if (StringUtils.isNotEmpty(requestService)) {

--- a/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/MutableHttpServletRequest.java
+++ b/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/util/interceptor/MutableHttpServletRequest.java
@@ -159,13 +159,15 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
                             "//Insert/*");
                         Node node = nl.item(0);
                         Element e = (Element) node;
-                        String namespaceUri = e.getAttribute("xmlns");
-                        if (!StringUtils.isEmpty(namespaceUri)) {
-                            String[] path = namespaceUri.split("/");
-                            String workspace = path[path.length - 1];
-                            value = workspace + ":" + node.getNodeName();
-                        } else {
-                            LOG.error("No namespaceUri found in Insert.");
+                        if (e != null) {
+                            String namespaceUri = e.getAttribute("xmlns");
+                            if (!StringUtils.isEmpty(namespaceUri)) {
+                                String[] path = namespaceUri.split("/");
+                                String workspace = path[path.length - 1];
+                                value = workspace + ":" + node.getNodeName();
+                            } else {
+                                LOG.error("No namespaceUri found in Insert.");
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This adds/fixes some checks in the interceptor to add support for `WPS`.
It also updates the jackson version to `2.14.3`.